### PR TITLE
Fix IE9< Array.indexOf() error

### DIFF
--- a/source/js/jquery-sortable.js
+++ b/source/js/jquery-sortable.js
@@ -387,7 +387,7 @@
       this.containers.push(container);
     },
     removeContainer: function (container) {
-      var i = $.inArray(container,this);
+      var i = $.inArray(container,this.containers);
       i!==-1 && remove(this.containers, i);
     },
     scrolled: function  (e) {


### PR DESCRIPTION
IE<9 doesn't have an .indexOf() function for Array.
