### PR TITLE
fixed getPointer & drag functions for touch screen

### DIFF
--- a/source/js/jquery-sortable.js
+++ b/source/js/jquery-sortable.js
@@ -268,8 +268,8 @@
                           groupDefaults.onDrag,
                           e)
 
-      var x = e.pageX || e.originalEvent.pageX,
-      y = e.pageY || e.originalEvent.pageY,
+      var x = e.pageX || e.originalEvent.targetTouches[0].pageX,
+      y = e.pageY || e.originalEvent.targetTouches[0].pageY,
       box = this.sameResultBox,
       t = this.options.tolerance
 
@@ -390,8 +390,8 @@
     },
     getPointer: function(e) {
       return {
-        left: e.pageX || e.originalEvent.pageX,
-        top: e.pageY || e.originalEvent.pageY
+        left: e.pageX || e.originalEvent.targetTouches[0].pageX,
+        top: e.pageY || e.originalEvent.targetTouches[0].pageY
       }
     },
     setupDelayTimer: function () {


### PR DESCRIPTION
getPointer and drag were not setting position when using a touch device.

This quick fix may not work properly when using multitouch but I didn't saw any problem on chrome emulation and on my phone.

There is multiple ways to get the touch event's position and I might not use the best one. Maybe someone with experience in the matter could improve this solution?
