### PR TITLE
Re-append placeholder on second hover over valid container with pullPlaceholder: false.

### DIFF
--- a/source/js/jquery-sortable.js
+++ b/source/js/jquery-sortable.js
@@ -274,8 +274,10 @@
       t = this.options.tolerance
 
       if(!box || box.top - t > y || box.bottom + t < y || box.left - t > x || box.right + t < x)
-        if(!this.searchValidTarget())
+        if(!this.searchValidTarget()){
           this.placeholder.detach()
+          this.lastAppendedItem = undefined
+        }
     },
     drop: function  (e) {
       this.toggleListeners('off')


### PR DESCRIPTION
When using two grouped containers and `pullPlaceholder: false` when the target container is empty, the placeholder appears correctly the first time an item is dragged to hover over the target container, but then if the item is dragged out of that container and back in, the placeholder does not appear again. See http://jsfiddle.net/jgerigmeyer/SmRM2/7/ for an example, and http://jsfiddle.net/jgerigmeyer/SmRM2/6/ for a working version using this PR.

This fixes https://github.com/johnny/jquery-sortable/issues/117.
