### PR TITLE
Update jquery.sortable.js Destroy

### DIFF
--- a/source/js/jquery-sortable.js
+++ b/source/js/jquery-sortable.js
@@ -626,6 +626,9 @@
         this.group.containers = $.grep(this.group.containers, function(val){
           return val != that
         })
+        
+      if(this.group)
+        this.group._destroy()
 
       $.each(this.items || [], function(){
         $.removeData(this, subContainerKey)


### PR DESCRIPTION
The destroy method doesn't clean itself properly. I dont know if this is the proper way of doing it, but in my code this works. Can you please make a full cleanup so no memory leaks are existing in case of spa ( Single page application )
