### PR TITLE
Pass former-container to onDrop if cancelled.

### DIFF
--- a/source/js/jquery-sortable.js
+++ b/source/js/jquery-sortable.js
@@ -290,12 +290,13 @@
 
       if(this.dragging){
         // processing Drop, check if placeholder is detached
-        if(this.placeholder.closest("html")[0])
+        if(this.placeholder.closest("html")[0]){
           this.placeholder.before(this.item).detach()
-        else
+          this.options.onDrop(this.item, this.getContainer(this.item), groupDefaults.onDrop, e)
+        } else {
           this.options.onCancel(this.item, this.itemContainer, groupDefaults.onCancel, e)
-
-        this.options.onDrop(this.item, this.getContainer(this.item), groupDefaults.onDrop, e)
+          this.options.onDrop(this.item, this.itemContainer, groupDefaults.onDrop, e)
+        }
 
         // cleanup
         this.clearDimensions()


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/johnny/jquery-sortable/pull/119 where the container is `undefined` when a drop is cancelled, thus throwing a JS error looking for `container.group.options` in `onDrop` method.
