### PR TITLE
CSS fix: force absolute position on .dragged (#164)

### DIFF
--- a/source/css/example.css
+++ b/source/css/example.css
@@ -3,7 +3,7 @@ body.dragging, body.dragging * {
 }
 
 .dragged {
-  position: absolute;
+  position: absolute !important;
   opacity: 0.5;
   z-index: 2000;
 }

--- a/source/css/jquery-sortable.css.sass
+++ b/source/css/jquery-sortable.css.sass
@@ -2,7 +2,7 @@ body.dragging, body.dragging *
   cursor: move !important
 
 .dragged
-  position: absolute
+  position: absolute !important
   top: 0
   opacity: .5
   z-index: 2000


### PR DESCRIPTION
Hi there,

Thanks for sharing that plugin.

Here's a quick fix for issue #164, which happens when dragged elements are relatively positioned.

Cheers
