### PR TITLE
update query-sortable.js

### DIFF
--- a/source/js/jquery-sortable.js
+++ b/source/js/jquery-sortable.js
@@ -675,6 +675,12 @@
   $.fn[pluginName] = function(methodOrOptions) {
     var args = Array.prototype.slice.call(arguments, 1)
 
+    // add option 'clear' to clear containerGroups for Turbolinks
+    if(typeof methodOrOptions === 'object' && methodOrOptions.clear){
+      containerGroups = [];
+      groupCounter = 0;
+    }
+    
     return this.map(function(){
       var $t = $(this),
       object = $t.data(pluginName)


### PR DESCRIPTION
Hi, I'm using Rails 4 + Turbolinks + jQuery-sortable, encountered an error "container.group not defined" while dropping item to a container. This is happening when using Turbolinks, click some links to go out and back to this page, then jquery-sortable got error. So, this is my solution.
